### PR TITLE
travis: add missing space is shell `test` invocation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ install:
   - if [ -n "$GETH_VERSION" ]; then python -m geth.install $GETH_VERSION; fi
   - if [ -n "$GETH_VERSION" ]; then export GETH_BINARY="$GETH_BASE_INSTALL_PATH/geth-$GETH_VERSION/bin/geth"; fi
   # install vyper if necessary.
-  - if [ -n "$INSTALL_VYPER"]; then pip install https://github.com/ethereum/vyper/archive/master.zip; fi
+  - if [ -n "$INSTALL_VYPER" ]; then pip install https://github.com/ethereum/vyper/archive/master.zip; fi
   # package
   - travis_retry pip install setuptools --upgrade
   - travis_retry pip install tox


### PR DESCRIPTION
### What was wrong?

Without the space, the command is always run - including in Python 2.7 builds, which fails with unfulfillable dependencies. (Vyper requires new Python - never had support for Python 2.7.)

### How was it fixed?

The shell's `test` invocation now has a space.

#### Cute Animal Picture

Source: [litoki@deviantart](https://litoki.deviantart.com/art/Space-Octopus-283905486)

![](https://pre00.deviantart.net/97a6/th/pre/i/2012/048/7/9/space_octopus_by_litoki-d4p12vi.jpg)